### PR TITLE
Move size settings to another ThemeData object

### DIFF
--- a/lib/src/components/button.dart
+++ b/lib/src/components/button.dart
@@ -286,72 +286,64 @@ class _ShadcnButtonState extends State<ShadcnButton> {
     };
   }
 
-  double defaultHeightForSize(ShadcnButtonSize size) {
-    return switch (size) {
-      ShadcnButtonSize.$default => 40,
-      ShadcnButtonSize.sm => 36,
-      ShadcnButtonSize.lg => 44,
-      ShadcnButtonSize.icon => 40,
-    };
+  ShadcnButtonSizeTheme buttonSizeTheme(
+      ShadcnThemeData theme, ShadcnButtonSize size) {
+    switch (size) {
+      case ShadcnButtonSize.sm:
+        return buttonTheme(theme).buttonSizesTheme.sm;
+      case ShadcnButtonSize.lg:
+        return buttonTheme(theme).buttonSizesTheme.lg;
+      case ShadcnButtonSize.icon:
+        return buttonTheme(theme).buttonSizesTheme.icon;
+      case ShadcnButtonSize.$default:
+        return buttonTheme(theme).buttonSizesTheme.$default;
+    }
+  }
+
+  double defaultHeightForSize(ShadcnThemeData theme, ShadcnButtonSize size) {
+    return buttonSizeTheme(theme, size).height;
   }
 
   double height(ShadcnThemeData theme) {
     if (widget.height != null) return widget.height!;
     if (widget.size != null) {
-      return defaultHeightForSize(widget.size!);
+      return defaultHeightForSize(theme, widget.size!);
     }
     if (buttonTheme(theme).height != null) {
       return buttonTheme(theme).height!;
     }
-    return defaultHeightForSize(size(theme) ?? ShadcnButtonSize.$default);
+    return defaultHeightForSize(theme, ShadcnButtonSize.$default);
   }
 
-  double? defaultWidthForSize(ShadcnButtonSize size) {
-    return switch (size) {
-      ShadcnButtonSize.icon => 40,
-      _ => null,
-    };
-  }
-
-  ShadcnButtonSize? size(ShadcnThemeData theme) {
-    if (widget.size != null) return widget.size!;
-    if (buttonTheme(theme).size != null) {
-      return buttonTheme(theme).size!;
-    }
-    return null;
+  double? defaultWidthForSize(ShadcnThemeData theme, ShadcnButtonSize size) {
+    return buttonSizeTheme(theme, size).width;
   }
 
   double? width(ShadcnThemeData theme) {
     if (widget.width != null) return widget.width!;
     if (widget.size != null) {
-      return defaultWidthForSize(widget.size!);
+      return defaultWidthForSize(theme, widget.size!);
     }
     if (buttonTheme(theme).width != null) {
       return buttonTheme(theme).width!;
     }
-    return defaultWidthForSize(size(theme) ?? ShadcnButtonSize.$default);
+    return defaultWidthForSize(theme, ShadcnButtonSize.$default);
   }
 
-  EdgeInsets defaultPaddingForSize(ShadcnButtonSize size) {
-    return switch (size) {
-      ShadcnButtonSize.$default =>
-        const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      ShadcnButtonSize.sm => const EdgeInsets.symmetric(horizontal: 12),
-      ShadcnButtonSize.lg =>
-        const EdgeInsets.symmetric(horizontal: 32, vertical: 8),
-      ShadcnButtonSize.icon => EdgeInsets.zero,
-    };
+  EdgeInsets defaultPaddingForSize(
+      ShadcnThemeData theme, ShadcnButtonSize size) {
+    return buttonSizeTheme(theme, size).padding;
   }
 
   EdgeInsets padding(ShadcnThemeData theme) {
     if (widget.padding != null) return widget.padding!;
-    if (size(theme) != null) {
-      return defaultPaddingForSize(size(theme)!);
+    if (widget.size != null) {
+      return defaultPaddingForSize(theme, widget.size!);
     }
     if (buttonTheme(theme).padding != null) {
       return buttonTheme(theme).padding!;
     }
-    return defaultPaddingForSize(ShadcnButtonSize.$default);
+    return defaultPaddingForSize(theme, ShadcnButtonSize.$default);
   }
 
   Color? background(ShadcnThemeData theme) {

--- a/lib/src/components/button.dart
+++ b/lib/src/components/button.dart
@@ -286,24 +286,24 @@ class _ShadcnButtonState extends State<ShadcnButton> {
     };
   }
 
-  ShadcnButtonSizeTheme buttonSizeTheme(
+  ShadcnButtonSizeTheme sizeTheme(
     ShadcnThemeData theme,
     ShadcnButtonSize size,
   ) {
     switch (size) {
       case ShadcnButtonSize.sm:
-        return buttonTheme(theme).buttonSizesTheme.sm;
+        return buttonTheme(theme).sizesTheme.sm;
       case ShadcnButtonSize.lg:
-        return buttonTheme(theme).buttonSizesTheme.lg;
+        return buttonTheme(theme).sizesTheme.lg;
       case ShadcnButtonSize.icon:
-        return buttonTheme(theme).buttonSizesTheme.icon;
+        return buttonTheme(theme).sizesTheme.icon;
       case ShadcnButtonSize.$default:
-        return buttonTheme(theme).buttonSizesTheme.$default;
+        return buttonTheme(theme).sizesTheme.$default;
     }
   }
 
   double defaultHeightForSize(ShadcnThemeData theme, ShadcnButtonSize size) {
-    return buttonSizeTheme(theme, size).height;
+    return sizeTheme(theme, size).height;
   }
 
   double height(ShadcnThemeData theme) {
@@ -315,7 +315,7 @@ class _ShadcnButtonState extends State<ShadcnButton> {
   }
 
   double? defaultWidthForSize(ShadcnThemeData theme, ShadcnButtonSize size) {
-    return buttonSizeTheme(theme, size).width;
+    return sizeTheme(theme, size).width;
   }
 
   double? width(ShadcnThemeData theme) {
@@ -330,7 +330,7 @@ class _ShadcnButtonState extends State<ShadcnButton> {
     ShadcnThemeData theme,
     ShadcnButtonSize size,
   ) {
-    return buttonSizeTheme(theme, size).padding;
+    return sizeTheme(theme, size).padding;
   }
 
   EdgeInsets padding(ShadcnThemeData theme) {

--- a/lib/src/components/button.dart
+++ b/lib/src/components/button.dart
@@ -309,9 +309,6 @@ class _ShadcnButtonState extends State<ShadcnButton> {
     if (widget.size != null) {
       return defaultHeightForSize(theme, widget.size!);
     }
-    if (buttonTheme(theme).height != null) {
-      return buttonTheme(theme).height!;
-    }
     return defaultHeightForSize(theme, ShadcnButtonSize.$default);
   }
 
@@ -323,9 +320,6 @@ class _ShadcnButtonState extends State<ShadcnButton> {
     if (widget.width != null) return widget.width!;
     if (widget.size != null) {
       return defaultWidthForSize(theme, widget.size!);
-    }
-    if (buttonTheme(theme).width != null) {
-      return buttonTheme(theme).width!;
     }
     return defaultWidthForSize(theme, ShadcnButtonSize.$default);
   }
@@ -339,9 +333,6 @@ class _ShadcnButtonState extends State<ShadcnButton> {
     if (widget.padding != null) return widget.padding!;
     if (widget.size != null) {
       return defaultPaddingForSize(theme, widget.size!);
-    }
-    if (buttonTheme(theme).padding != null) {
-      return buttonTheme(theme).padding!;
     }
     return defaultPaddingForSize(theme, ShadcnButtonSize.$default);
   }

--- a/lib/src/components/button.dart
+++ b/lib/src/components/button.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:shadcn_ui/shadcn_ui.dart';
+import 'package:shadcn_ui/src/theme/components/button.dart';
+import 'package:shadcn_ui/src/theme/data.dart';
+import 'package:shadcn_ui/src/theme/theme.dart';
 import 'package:shadcn_ui/src/utils/debug_check.dart';
 
 typedef FocusWidgetBuilder = Widget Function(
@@ -226,7 +228,6 @@ class ShadcnButton extends StatefulWidget {
   final Widget? icon;
   final Widget? text;
   final ShadcnButtonVariant variant;
-
   final ShadcnButtonSize? size;
   final bool? applyIconColorFilter;
   final MouseCursor? cursor;
@@ -292,13 +293,13 @@ class _ShadcnButtonState extends State<ShadcnButton> {
   ) {
     switch (size) {
       case ShadcnButtonSize.sm:
-        return buttonTheme(theme).sizesTheme.sm;
+        return buttonTheme(theme).sizesTheme!.sm!;
       case ShadcnButtonSize.lg:
-        return buttonTheme(theme).sizesTheme.lg;
+        return buttonTheme(theme).sizesTheme!.lg!;
       case ShadcnButtonSize.icon:
-        return buttonTheme(theme).sizesTheme.icon;
+        return buttonTheme(theme).sizesTheme!.icon!;
       case ShadcnButtonSize.$default:
-        return buttonTheme(theme).sizesTheme.$default;
+        return buttonTheme(theme).sizesTheme!.$default!;
     }
   }
 

--- a/lib/src/components/button.dart
+++ b/lib/src/components/button.dart
@@ -287,7 +287,9 @@ class _ShadcnButtonState extends State<ShadcnButton> {
   }
 
   ShadcnButtonSizeTheme buttonSizeTheme(
-      ShadcnThemeData theme, ShadcnButtonSize size) {
+    ShadcnThemeData theme,
+    ShadcnButtonSize size,
+  ) {
     switch (size) {
       case ShadcnButtonSize.sm:
         return buttonTheme(theme).buttonSizesTheme.sm;
@@ -309,7 +311,7 @@ class _ShadcnButtonState extends State<ShadcnButton> {
     if (widget.size != null) {
       return defaultHeightForSize(theme, widget.size!);
     }
-    return defaultHeightForSize(theme, ShadcnButtonSize.$default);
+    return defaultHeightForSize(theme, buttonTheme(theme).size);
   }
 
   double? defaultWidthForSize(ShadcnThemeData theme, ShadcnButtonSize size) {
@@ -321,11 +323,13 @@ class _ShadcnButtonState extends State<ShadcnButton> {
     if (widget.size != null) {
       return defaultWidthForSize(theme, widget.size!);
     }
-    return defaultWidthForSize(theme, ShadcnButtonSize.$default);
+    return defaultWidthForSize(theme, buttonTheme(theme).size);
   }
 
   EdgeInsets defaultPaddingForSize(
-      ShadcnThemeData theme, ShadcnButtonSize size) {
+    ShadcnThemeData theme,
+    ShadcnButtonSize size,
+  ) {
     return buttonSizeTheme(theme, size).padding;
   }
 
@@ -334,7 +338,7 @@ class _ShadcnButtonState extends State<ShadcnButton> {
     if (widget.size != null) {
       return defaultPaddingForSize(theme, widget.size!);
     }
-    return defaultPaddingForSize(theme, ShadcnButtonSize.$default);
+    return defaultPaddingForSize(theme, buttonTheme(theme).size);
   }
 
   Color? background(ShadcnThemeData theme) {

--- a/lib/src/theme/components/button.dart
+++ b/lib/src/theme/components/button.dart
@@ -180,7 +180,7 @@ class ShadcnButtonTheme {
   final bool merge;
   final bool applyIconColorFilter;
   final MouseCursor? cursor;
-  final ShadcnButtonSize? size;
+  final ShadcnButtonSize size;
   final ShadcnButtonSizesTheme buttonSizesTheme;
   final Color? backgroundColor;
   final Color? hoverBackgroundColor;

--- a/lib/src/theme/components/button.dart
+++ b/lib/src/theme/components/button.dart
@@ -5,6 +5,198 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/components/button.dart';
 
+/// The theme for ShadcnButton.
+///
+/// Use this class to override some properties to all buttons in just one place.
+@immutable
+class ShadcnButtonTheme {
+  const ShadcnButtonTheme({
+    this.merge = true,
+    this.applyIconColorFilter = true,
+    this.cursor,
+    this.size = ShadcnButtonSize.$default,
+    this.sizesTheme = const ShadcnButtonSizesTheme(),
+    this.backgroundColor,
+    this.hoverBackgroundColor,
+    this.foregroundColor,
+    this.hoverForegroundColor,
+    this.border,
+    this.radius,
+    this.pressedBackgroundColor,
+    this.pressedForegroundColor,
+    this.shadows,
+    this.gradient,
+    this.textDecoration,
+    this.hoverTextDecoration,
+    this.focusBuilder,
+  });
+
+  final bool merge;
+  final bool applyIconColorFilter;
+  final MouseCursor? cursor;
+  final ShadcnButtonSize size;
+  final ShadcnButtonSizesTheme sizesTheme;
+  final Color? backgroundColor;
+  final Color? hoverBackgroundColor;
+  final Color? foregroundColor;
+  final Color? hoverForegroundColor;
+  final BoxBorder? border;
+  final BorderRadius? radius;
+  final Color? pressedBackgroundColor;
+  final Color? pressedForegroundColor;
+  final List<BoxShadow>? shadows;
+  final Gradient? gradient;
+  final TextDecoration? textDecoration;
+  final TextDecoration? hoverTextDecoration;
+  final FocusWidgetBuilder? focusBuilder;
+
+  static ShadcnButtonTheme lerp(
+    ShadcnButtonTheme a,
+    ShadcnButtonTheme b,
+    double t,
+  ) {
+    if (identical(a, b)) return a;
+    return ShadcnButtonTheme(
+      applyIconColorFilter: b.applyIconColorFilter,
+      sizesTheme: ShadcnButtonSizesTheme.lerp(
+        a.sizesTheme,
+        b.sizesTheme,
+        t,
+      ),
+      backgroundColor: Color.lerp(a.backgroundColor, b.backgroundColor, t),
+      hoverBackgroundColor:
+          Color.lerp(a.hoverBackgroundColor, b.hoverBackgroundColor, t),
+      foregroundColor: Color.lerp(a.foregroundColor, b.foregroundColor, t),
+      hoverForegroundColor:
+          Color.lerp(a.hoverForegroundColor, b.hoverForegroundColor, t),
+      border: b.border,
+      radius: BorderRadius.lerp(a.radius, b.radius, t),
+      pressedBackgroundColor:
+          Color.lerp(a.pressedBackgroundColor, b.pressedBackgroundColor, t),
+      pressedForegroundColor:
+          Color.lerp(a.pressedForegroundColor, b.pressedForegroundColor, t),
+      shadows: b.shadows,
+      gradient: b.gradient,
+      textDecoration: b.textDecoration,
+      hoverTextDecoration: b.hoverTextDecoration,
+      cursor: b.cursor,
+      focusBuilder: b.focusBuilder,
+      size: b.size,
+    );
+  }
+
+  ShadcnButtonTheme copyWith({
+    bool? applyIconColorFilter,
+    MouseCursor? cursor,
+    MouseCursor? disabledCursor,
+    ShadcnButtonSize? size,
+    ShadcnButtonSizesTheme? buttonSizesTheme,
+    Color? backgroundColor,
+    Color? hoverBackgroundColor,
+    Color? foregroundColor,
+    Color? hoverForegroundColor,
+    BoxBorder? border,
+    BorderRadius? radius,
+    Color? pressedBackgroundColor,
+    Color? pressedForegroundColor,
+    List<BoxShadow>? shadows,
+    Gradient? gradient,
+    TextDecoration? textDecoration,
+    TextDecoration? hoverTextDecoration,
+    FocusWidgetBuilder? focusBuilder,
+  }) {
+    return ShadcnButtonTheme(
+      applyIconColorFilter: applyIconColorFilter ?? this.applyIconColorFilter,
+      cursor: cursor ?? this.cursor,
+      size: size ?? this.size,
+      sizesTheme: buttonSizesTheme ?? this.sizesTheme,
+      backgroundColor: backgroundColor ?? this.backgroundColor,
+      hoverBackgroundColor: hoverBackgroundColor ?? this.hoverBackgroundColor,
+      foregroundColor: foregroundColor ?? this.foregroundColor,
+      hoverForegroundColor: hoverForegroundColor ?? this.hoverForegroundColor,
+      border: border ?? this.border,
+      radius: radius ?? this.radius,
+      pressedBackgroundColor:
+          pressedBackgroundColor ?? this.pressedBackgroundColor,
+      pressedForegroundColor:
+          pressedForegroundColor ?? this.pressedForegroundColor,
+      shadows: shadows ?? this.shadows,
+      gradient: gradient ?? this.gradient,
+      textDecoration: textDecoration ?? this.textDecoration,
+      hoverTextDecoration: hoverTextDecoration ?? this.hoverTextDecoration,
+      focusBuilder: focusBuilder ?? this.focusBuilder,
+    );
+  }
+
+  ShadcnButtonTheme mergeWith(ShadcnButtonTheme? other) {
+    if (other == null) return this;
+    if (!other.merge) return other;
+    return copyWith(
+      applyIconColorFilter: other.applyIconColorFilter,
+      cursor: other.cursor,
+      size: other.size,
+      backgroundColor: other.backgroundColor,
+      hoverBackgroundColor: other.hoverBackgroundColor,
+      foregroundColor: other.foregroundColor,
+      hoverForegroundColor: other.hoverForegroundColor,
+      border: other.border,
+      radius: other.radius,
+      pressedBackgroundColor: other.pressedBackgroundColor,
+      pressedForegroundColor: other.pressedForegroundColor,
+      shadows: other.shadows,
+      gradient: other.gradient,
+      textDecoration: other.textDecoration,
+      hoverTextDecoration: other.hoverTextDecoration,
+      focusBuilder: other.focusBuilder,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is ShadcnButtonTheme &&
+        other.applyIconColorFilter == applyIconColorFilter &&
+        other.cursor == cursor &&
+        other.size == size &&
+        other.sizesTheme == sizesTheme &&
+        other.backgroundColor == backgroundColor &&
+        other.hoverBackgroundColor == hoverBackgroundColor &&
+        other.foregroundColor == foregroundColor &&
+        other.hoverForegroundColor == hoverForegroundColor &&
+        other.border == border &&
+        other.radius == radius &&
+        other.pressedBackgroundColor == pressedBackgroundColor &&
+        other.pressedForegroundColor == pressedForegroundColor &&
+        listEquals(other.shadows, shadows) &&
+        other.gradient == gradient &&
+        other.textDecoration == textDecoration &&
+        other.hoverTextDecoration == hoverTextDecoration &&
+        other.focusBuilder == focusBuilder;
+  }
+
+  @override
+  int get hashCode {
+    return applyIconColorFilter.hashCode ^
+        cursor.hashCode ^
+        size.hashCode ^
+        sizesTheme.hashCode ^
+        backgroundColor.hashCode ^
+        hoverBackgroundColor.hashCode ^
+        foregroundColor.hashCode ^
+        hoverForegroundColor.hashCode ^
+        border.hashCode ^
+        radius.hashCode ^
+        pressedBackgroundColor.hashCode ^
+        pressedForegroundColor.hashCode ^
+        shadows.hashCode ^
+        gradient.hashCode ^
+        textDecoration.hashCode ^
+        hoverTextDecoration.hashCode ^
+        focusBuilder.hashCode;
+  }
+}
+
 // The theme for an individual size of ShadcnButton.
 @immutable
 class ShadcnButtonSizeTheme {
@@ -149,196 +341,4 @@ class ShadcnButtonSizesTheme {
   @override
   int get hashCode =>
       $default.hashCode ^ sm.hashCode ^ lg.hashCode ^ icon.hashCode;
-}
-
-/// The theme for ShadcnButton.
-///
-/// Use this class to override some properties to all buttons in just one place.
-@immutable
-class ShadcnButtonTheme {
-  const ShadcnButtonTheme({
-    this.merge = true,
-    this.applyIconColorFilter = true,
-    this.cursor,
-    this.size = ShadcnButtonSize.$default,
-    this.buttonSizesTheme = const ShadcnButtonSizesTheme(),
-    this.backgroundColor,
-    this.hoverBackgroundColor,
-    this.foregroundColor,
-    this.hoverForegroundColor,
-    this.border,
-    this.radius,
-    this.pressedBackgroundColor,
-    this.pressedForegroundColor,
-    this.shadows,
-    this.gradient,
-    this.textDecoration,
-    this.hoverTextDecoration,
-    this.focusBuilder,
-  });
-
-  final bool merge;
-  final bool applyIconColorFilter;
-  final MouseCursor? cursor;
-  final ShadcnButtonSize size;
-  final ShadcnButtonSizesTheme buttonSizesTheme;
-  final Color? backgroundColor;
-  final Color? hoverBackgroundColor;
-  final Color? foregroundColor;
-  final Color? hoverForegroundColor;
-  final BoxBorder? border;
-  final BorderRadius? radius;
-  final Color? pressedBackgroundColor;
-  final Color? pressedForegroundColor;
-  final List<BoxShadow>? shadows;
-  final Gradient? gradient;
-  final TextDecoration? textDecoration;
-  final TextDecoration? hoverTextDecoration;
-  final FocusWidgetBuilder? focusBuilder;
-
-  static ShadcnButtonTheme lerp(
-    ShadcnButtonTheme a,
-    ShadcnButtonTheme b,
-    double t,
-  ) {
-    if (identical(a, b)) return a;
-    return ShadcnButtonTheme(
-      applyIconColorFilter: b.applyIconColorFilter,
-      buttonSizesTheme: ShadcnButtonSizesTheme.lerp(
-        a.buttonSizesTheme,
-        b.buttonSizesTheme,
-        t,
-      ),
-      backgroundColor: Color.lerp(a.backgroundColor, b.backgroundColor, t),
-      hoverBackgroundColor:
-          Color.lerp(a.hoverBackgroundColor, b.hoverBackgroundColor, t),
-      foregroundColor: Color.lerp(a.foregroundColor, b.foregroundColor, t),
-      hoverForegroundColor:
-          Color.lerp(a.hoverForegroundColor, b.hoverForegroundColor, t),
-      border: b.border,
-      radius: BorderRadius.lerp(a.radius, b.radius, t),
-      pressedBackgroundColor:
-          Color.lerp(a.pressedBackgroundColor, b.pressedBackgroundColor, t),
-      pressedForegroundColor:
-          Color.lerp(a.pressedForegroundColor, b.pressedForegroundColor, t),
-      shadows: b.shadows,
-      gradient: b.gradient,
-      textDecoration: b.textDecoration,
-      hoverTextDecoration: b.hoverTextDecoration,
-      cursor: b.cursor,
-      focusBuilder: b.focusBuilder,
-      size: b.size,
-    );
-  }
-
-  ShadcnButtonTheme copyWith({
-    bool? applyIconColorFilter,
-    MouseCursor? cursor,
-    MouseCursor? disabledCursor,
-    ShadcnButtonSize? size,
-    ShadcnButtonSizesTheme? buttonSizesTheme,
-    Color? backgroundColor,
-    Color? hoverBackgroundColor,
-    Color? foregroundColor,
-    Color? hoverForegroundColor,
-    BoxBorder? border,
-    BorderRadius? radius,
-    Color? pressedBackgroundColor,
-    Color? pressedForegroundColor,
-    List<BoxShadow>? shadows,
-    Gradient? gradient,
-    TextDecoration? textDecoration,
-    TextDecoration? hoverTextDecoration,
-    FocusWidgetBuilder? focusBuilder,
-  }) {
-    return ShadcnButtonTheme(
-      applyIconColorFilter: applyIconColorFilter ?? this.applyIconColorFilter,
-      cursor: cursor ?? this.cursor,
-      size: size ?? this.size,
-      buttonSizesTheme: buttonSizesTheme ?? this.buttonSizesTheme,
-      backgroundColor: backgroundColor ?? this.backgroundColor,
-      hoverBackgroundColor: hoverBackgroundColor ?? this.hoverBackgroundColor,
-      foregroundColor: foregroundColor ?? this.foregroundColor,
-      hoverForegroundColor: hoverForegroundColor ?? this.hoverForegroundColor,
-      border: border ?? this.border,
-      radius: radius ?? this.radius,
-      pressedBackgroundColor:
-          pressedBackgroundColor ?? this.pressedBackgroundColor,
-      pressedForegroundColor:
-          pressedForegroundColor ?? this.pressedForegroundColor,
-      shadows: shadows ?? this.shadows,
-      gradient: gradient ?? this.gradient,
-      textDecoration: textDecoration ?? this.textDecoration,
-      hoverTextDecoration: hoverTextDecoration ?? this.hoverTextDecoration,
-      focusBuilder: focusBuilder ?? this.focusBuilder,
-    );
-  }
-
-  ShadcnButtonTheme mergeWith(ShadcnButtonTheme? other) {
-    if (other == null) return this;
-    if (!other.merge) return other;
-    return copyWith(
-      applyIconColorFilter: other.applyIconColorFilter,
-      cursor: other.cursor,
-      size: other.size,
-      backgroundColor: other.backgroundColor,
-      hoverBackgroundColor: other.hoverBackgroundColor,
-      foregroundColor: other.foregroundColor,
-      hoverForegroundColor: other.hoverForegroundColor,
-      border: other.border,
-      radius: other.radius,
-      pressedBackgroundColor: other.pressedBackgroundColor,
-      pressedForegroundColor: other.pressedForegroundColor,
-      shadows: other.shadows,
-      gradient: other.gradient,
-      textDecoration: other.textDecoration,
-      hoverTextDecoration: other.hoverTextDecoration,
-      focusBuilder: other.focusBuilder,
-    );
-  }
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-
-    return other is ShadcnButtonTheme &&
-        other.applyIconColorFilter == applyIconColorFilter &&
-        other.cursor == cursor &&
-        other.size == size &&
-        other.buttonSizesTheme == buttonSizesTheme &&
-        other.backgroundColor == backgroundColor &&
-        other.hoverBackgroundColor == hoverBackgroundColor &&
-        other.foregroundColor == foregroundColor &&
-        other.hoverForegroundColor == hoverForegroundColor &&
-        other.border == border &&
-        other.radius == radius &&
-        other.pressedBackgroundColor == pressedBackgroundColor &&
-        other.pressedForegroundColor == pressedForegroundColor &&
-        listEquals(other.shadows, shadows) &&
-        other.gradient == gradient &&
-        other.textDecoration == textDecoration &&
-        other.hoverTextDecoration == hoverTextDecoration &&
-        other.focusBuilder == focusBuilder;
-  }
-
-  @override
-  int get hashCode {
-    return applyIconColorFilter.hashCode ^
-        cursor.hashCode ^
-        size.hashCode ^
-        buttonSizesTheme.hashCode ^
-        backgroundColor.hashCode ^
-        hoverBackgroundColor.hashCode ^
-        foregroundColor.hashCode ^
-        hoverForegroundColor.hashCode ^
-        border.hashCode ^
-        radius.hashCode ^
-        pressedBackgroundColor.hashCode ^
-        pressedForegroundColor.hashCode ^
-        shadows.hashCode ^
-        gradient.hashCode ^
-        textDecoration.hashCode ^
-        hoverTextDecoration.hashCode ^
-        focusBuilder.hashCode;
-  }
 }

--- a/lib/src/theme/components/button.dart
+++ b/lib/src/theme/components/button.dart
@@ -2,6 +2,47 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/components/button.dart';
 
+// The theme for an individual size of ShadcnButton.
+@immutable
+class ShadcnButtonSizeTheme {
+  const ShadcnButtonSizeTheme({
+    required this.height,
+    required this.padding,
+    this.width,
+  });
+  final double height;
+  final EdgeInsets padding;
+  final double? width;
+}
+
+// The theme for the predefined sizes of ShadcnButton.
+@immutable
+class ShadcnButtonSizesTheme {
+  const ShadcnButtonSizesTheme({
+    this.$default = const ShadcnButtonSizeTheme(
+      height: 40,
+      padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+    ),
+    this.sm = const ShadcnButtonSizeTheme(
+      height: 36,
+      padding: EdgeInsets.symmetric(horizontal: 12),
+    ),
+    this.lg = const ShadcnButtonSizeTheme(
+      height: 44,
+      padding: EdgeInsets.symmetric(horizontal: 32, vertical: 8),
+    ),
+    this.icon = const ShadcnButtonSizeTheme(
+      height: 40,
+      width: 40,
+      padding: EdgeInsets.zero,
+    ),
+  });
+  final ShadcnButtonSizeTheme $default;
+  final ShadcnButtonSizeTheme sm;
+  final ShadcnButtonSizeTheme lg;
+  final ShadcnButtonSizeTheme icon;
+}
+
 /// The theme for ShadcnButton.
 ///
 /// Use this class to override some properties to all buttons in just one place.
@@ -12,6 +53,7 @@ class ShadcnButtonTheme {
     this.applyIconColorFilter = true,
     this.cursor,
     this.size = ShadcnButtonSize.$default,
+    this.buttonSizesTheme = const ShadcnButtonSizesTheme(),
     this.width,
     this.height,
     this.padding,
@@ -50,6 +92,7 @@ class ShadcnButtonTheme {
   final TextDecoration? textDecoration;
   final TextDecoration? hoverTextDecoration;
   final FocusWidgetBuilder? focusBuilder;
+  final ShadcnButtonSizesTheme buttonSizesTheme;
 
   static ShadcnButtonTheme lerp(
     ShadcnButtonTheme a,

--- a/lib/src/theme/components/button.dart
+++ b/lib/src/theme/components/button.dart
@@ -1,4 +1,7 @@
+import 'dart:ui';
+
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/components/button.dart';
 
@@ -6,19 +9,70 @@ import 'package:shadcn_ui/src/components/button.dart';
 @immutable
 class ShadcnButtonSizeTheme {
   const ShadcnButtonSizeTheme({
+    this.merge = true,
     required this.height,
     required this.padding,
     this.width,
   });
+  final bool merge;
   final double height;
   final EdgeInsets padding;
   final double? width;
+
+  ShadcnButtonSizeTheme copyWith({
+    double? height,
+    EdgeInsets? padding,
+    double? width,
+  }) {
+    return ShadcnButtonSizeTheme(
+      height: height ?? this.height,
+      padding: padding ?? this.padding,
+      width: width ?? this.width,
+    );
+  }
+
+  static ShadcnButtonSizeTheme lerp(
+    ShadcnButtonSizeTheme a,
+    ShadcnButtonSizeTheme b,
+    double t,
+  ) {
+    if (identical(a, b)) return a;
+    return ShadcnButtonSizeTheme(
+      height: lerpDouble(a.height, b.height, t)!,
+      padding: EdgeInsets.lerp(a.padding, b.padding, t)!,
+      width: lerpDouble(a.width, b.width, t),
+    );
+  }
+
+  ShadcnButtonSizeTheme mergeWith(ShadcnButtonSizeTheme? other) {
+    if (other == null) return this;
+    if (!other.merge) return other;
+    return copyWith(
+      height: other.height,
+      padding: other.padding,
+      width: other.width,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is ShadcnButtonSizeTheme &&
+        other.height == height &&
+        other.padding == padding &&
+        other.width == width;
+  }
+
+  @override
+  int get hashCode => height.hashCode ^ padding.hashCode ^ width.hashCode;
 }
 
 // The theme for the predefined sizes of ShadcnButton.
 @immutable
 class ShadcnButtonSizesTheme {
   const ShadcnButtonSizesTheme({
+    this.merge = true,
     this.$default = const ShadcnButtonSizeTheme(
       height: 40,
       padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -37,10 +91,64 @@ class ShadcnButtonSizesTheme {
       padding: EdgeInsets.zero,
     ),
   });
+  final bool merge;
   final ShadcnButtonSizeTheme $default;
   final ShadcnButtonSizeTheme sm;
   final ShadcnButtonSizeTheme lg;
   final ShadcnButtonSizeTheme icon;
+
+  static ShadcnButtonSizesTheme lerp(
+    ShadcnButtonSizesTheme a,
+    ShadcnButtonSizesTheme b,
+    double t,
+  ) {
+    if (identical(a, b)) return a;
+    return ShadcnButtonSizesTheme(
+      $default: ShadcnButtonSizeTheme.lerp(a.$default, b.$default, t),
+      sm: ShadcnButtonSizeTheme.lerp(a.sm, b.sm, t),
+      lg: ShadcnButtonSizeTheme.lerp(a.lg, b.lg, t),
+      icon: ShadcnButtonSizeTheme.lerp(a.icon, b.icon, t),
+    );
+  }
+
+  ShadcnButtonSizesTheme copyWith({
+    ShadcnButtonSizeTheme? $default,
+    ShadcnButtonSizeTheme? sm,
+    ShadcnButtonSizeTheme? lg,
+    ShadcnButtonSizeTheme? icon,
+  }) {
+    return ShadcnButtonSizesTheme(
+      $default: $default ?? this.$default,
+      sm: sm ?? this.sm,
+      lg: lg ?? this.lg,
+      icon: icon ?? this.icon,
+    );
+  }
+
+  ShadcnButtonSizesTheme mergeWith(ShadcnButtonSizesTheme? other) {
+    if (other == null) return this;
+    if (!other.merge) return other;
+    return copyWith(
+      $default: other.$default,
+      sm: other.sm,
+      lg: other.lg,
+      icon: other.icon,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ShadcnButtonSizesTheme &&
+        other.$default == $default &&
+        other.sm == sm &&
+        other.lg == lg &&
+        other.icon == icon;
+  }
+
+  @override
+  int get hashCode =>
+      $default.hashCode ^ sm.hashCode ^ lg.hashCode ^ icon.hashCode;
 }
 
 /// The theme for ShadcnButton.
@@ -54,9 +162,6 @@ class ShadcnButtonTheme {
     this.cursor,
     this.size = ShadcnButtonSize.$default,
     this.buttonSizesTheme = const ShadcnButtonSizesTheme(),
-    this.width,
-    this.height,
-    this.padding,
     this.backgroundColor,
     this.hoverBackgroundColor,
     this.foregroundColor,
@@ -76,9 +181,7 @@ class ShadcnButtonTheme {
   final bool applyIconColorFilter;
   final MouseCursor? cursor;
   final ShadcnButtonSize? size;
-  final double? width;
-  final double? height;
-  final EdgeInsets? padding;
+  final ShadcnButtonSizesTheme buttonSizesTheme;
   final Color? backgroundColor;
   final Color? hoverBackgroundColor;
   final Color? foregroundColor;
@@ -92,7 +195,6 @@ class ShadcnButtonTheme {
   final TextDecoration? textDecoration;
   final TextDecoration? hoverTextDecoration;
   final FocusWidgetBuilder? focusBuilder;
-  final ShadcnButtonSizesTheme buttonSizesTheme;
 
   static ShadcnButtonTheme lerp(
     ShadcnButtonTheme a,
@@ -102,9 +204,11 @@ class ShadcnButtonTheme {
     if (identical(a, b)) return a;
     return ShadcnButtonTheme(
       applyIconColorFilter: b.applyIconColorFilter,
-      width: b.width,
-      height: b.height,
-      padding: EdgeInsets.lerp(a.padding, b.padding, t),
+      buttonSizesTheme: ShadcnButtonSizesTheme.lerp(
+        a.buttonSizesTheme,
+        b.buttonSizesTheme,
+        t,
+      ),
       backgroundColor: Color.lerp(a.backgroundColor, b.backgroundColor, t),
       hoverBackgroundColor:
           Color.lerp(a.hoverBackgroundColor, b.hoverBackgroundColor, t),
@@ -132,9 +236,7 @@ class ShadcnButtonTheme {
     MouseCursor? cursor,
     MouseCursor? disabledCursor,
     ShadcnButtonSize? size,
-    double? width,
-    double? height,
-    EdgeInsets? padding,
+    ShadcnButtonSizesTheme? buttonSizesTheme,
     Color? backgroundColor,
     Color? hoverBackgroundColor,
     Color? foregroundColor,
@@ -153,9 +255,7 @@ class ShadcnButtonTheme {
       applyIconColorFilter: applyIconColorFilter ?? this.applyIconColorFilter,
       cursor: cursor ?? this.cursor,
       size: size ?? this.size,
-      width: width ?? this.width,
-      height: height ?? this.height,
-      padding: padding ?? this.padding,
+      buttonSizesTheme: buttonSizesTheme ?? this.buttonSizesTheme,
       backgroundColor: backgroundColor ?? this.backgroundColor,
       hoverBackgroundColor: hoverBackgroundColor ?? this.hoverBackgroundColor,
       foregroundColor: foregroundColor ?? this.foregroundColor,
@@ -181,9 +281,6 @@ class ShadcnButtonTheme {
       applyIconColorFilter: other.applyIconColorFilter,
       cursor: other.cursor,
       size: other.size,
-      width: other.width,
-      height: other.height,
-      padding: other.padding,
       backgroundColor: other.backgroundColor,
       hoverBackgroundColor: other.hoverBackgroundColor,
       foregroundColor: other.foregroundColor,
@@ -208,9 +305,7 @@ class ShadcnButtonTheme {
         other.applyIconColorFilter == applyIconColorFilter &&
         other.cursor == cursor &&
         other.size == size &&
-        other.width == width &&
-        other.height == height &&
-        other.padding == padding &&
+        other.buttonSizesTheme == buttonSizesTheme &&
         other.backgroundColor == backgroundColor &&
         other.hoverBackgroundColor == hoverBackgroundColor &&
         other.foregroundColor == foregroundColor &&
@@ -231,9 +326,7 @@ class ShadcnButtonTheme {
     return applyIconColorFilter.hashCode ^
         cursor.hashCode ^
         size.hashCode ^
-        width.hashCode ^
-        height.hashCode ^
-        padding.hashCode ^
+        buttonSizesTheme.hashCode ^
         backgroundColor.hashCode ^
         hoverBackgroundColor.hashCode ^
         foregroundColor.hashCode ^

--- a/lib/src/theme/components/button.dart
+++ b/lib/src/theme/components/button.dart
@@ -15,7 +15,7 @@ class ShadcnButtonTheme {
     this.applyIconColorFilter = true,
     this.cursor,
     this.size = ShadcnButtonSize.$default,
-    this.sizesTheme = const ShadcnButtonSizesTheme(),
+    this.sizesTheme,
     this.backgroundColor,
     this.hoverBackgroundColor,
     this.foregroundColor,
@@ -30,12 +30,11 @@ class ShadcnButtonTheme {
     this.hoverTextDecoration,
     this.focusBuilder,
   });
-
   final bool merge;
   final bool applyIconColorFilter;
   final MouseCursor? cursor;
   final ShadcnButtonSize size;
-  final ShadcnButtonSizesTheme sizesTheme;
+  final ShadcnButtonSizesTheme? sizesTheme;
   final Color? backgroundColor;
   final Color? hoverBackgroundColor;
   final Color? foregroundColor;
@@ -90,7 +89,7 @@ class ShadcnButtonTheme {
     MouseCursor? cursor,
     MouseCursor? disabledCursor,
     ShadcnButtonSize? size,
-    ShadcnButtonSizesTheme? buttonSizesTheme,
+    ShadcnButtonSizesTheme? sizesTheme,
     Color? backgroundColor,
     Color? hoverBackgroundColor,
     Color? foregroundColor,
@@ -109,7 +108,7 @@ class ShadcnButtonTheme {
       applyIconColorFilter: applyIconColorFilter ?? this.applyIconColorFilter,
       cursor: cursor ?? this.cursor,
       size: size ?? this.size,
-      sizesTheme: buttonSizesTheme ?? this.sizesTheme,
+      sizesTheme: sizesTheme ?? this.sizesTheme,
       backgroundColor: backgroundColor ?? this.backgroundColor,
       hoverBackgroundColor: hoverBackgroundColor ?? this.hoverBackgroundColor,
       foregroundColor: foregroundColor ?? this.foregroundColor,
@@ -223,16 +222,16 @@ class ShadcnButtonSizeTheme {
     );
   }
 
-  static ShadcnButtonSizeTheme lerp(
-    ShadcnButtonSizeTheme a,
-    ShadcnButtonSizeTheme b,
+  static ShadcnButtonSizeTheme? lerp(
+    ShadcnButtonSizeTheme? a,
+    ShadcnButtonSizeTheme? b,
     double t,
   ) {
     if (identical(a, b)) return a;
     return ShadcnButtonSizeTheme(
-      height: lerpDouble(a.height, b.height, t)!,
-      padding: EdgeInsets.lerp(a.padding, b.padding, t)!,
-      width: lerpDouble(a.width, b.width, t),
+      height: lerpDouble(a?.height, b?.height, t)!,
+      padding: EdgeInsets.lerp(a?.padding, b?.padding, t)!,
+      width: lerpDouble(a?.width, b?.width, t),
     );
   }
 
@@ -265,41 +264,28 @@ class ShadcnButtonSizeTheme {
 class ShadcnButtonSizesTheme {
   const ShadcnButtonSizesTheme({
     this.merge = true,
-    this.$default = const ShadcnButtonSizeTheme(
-      height: 40,
-      padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-    ),
-    this.sm = const ShadcnButtonSizeTheme(
-      height: 36,
-      padding: EdgeInsets.symmetric(horizontal: 12),
-    ),
-    this.lg = const ShadcnButtonSizeTheme(
-      height: 44,
-      padding: EdgeInsets.symmetric(horizontal: 32, vertical: 8),
-    ),
-    this.icon = const ShadcnButtonSizeTheme(
-      height: 40,
-      width: 40,
-      padding: EdgeInsets.zero,
-    ),
+    this.$default,
+    this.sm,
+    this.lg,
+    this.icon,
   });
   final bool merge;
-  final ShadcnButtonSizeTheme $default;
-  final ShadcnButtonSizeTheme sm;
-  final ShadcnButtonSizeTheme lg;
-  final ShadcnButtonSizeTheme icon;
+  final ShadcnButtonSizeTheme? $default;
+  final ShadcnButtonSizeTheme? sm;
+  final ShadcnButtonSizeTheme? lg;
+  final ShadcnButtonSizeTheme? icon;
 
-  static ShadcnButtonSizesTheme lerp(
-    ShadcnButtonSizesTheme a,
-    ShadcnButtonSizesTheme b,
+  static ShadcnButtonSizesTheme? lerp(
+    ShadcnButtonSizesTheme? a,
+    ShadcnButtonSizesTheme? b,
     double t,
   ) {
     if (identical(a, b)) return a;
     return ShadcnButtonSizesTheme(
-      $default: ShadcnButtonSizeTheme.lerp(a.$default, b.$default, t),
-      sm: ShadcnButtonSizeTheme.lerp(a.sm, b.sm, t),
-      lg: ShadcnButtonSizeTheme.lerp(a.lg, b.lg, t),
-      icon: ShadcnButtonSizeTheme.lerp(a.icon, b.icon, t),
+      $default: ShadcnButtonSizeTheme.lerp(a?.$default, b?.$default, t),
+      sm: ShadcnButtonSizeTheme.lerp(a?.sm, b?.sm, t),
+      lg: ShadcnButtonSizeTheme.lerp(a?.lg, b?.lg, t),
+      icon: ShadcnButtonSizeTheme.lerp(a?.icon, b?.icon, t),
     );
   }
 

--- a/lib/src/theme/data.dart
+++ b/lib/src/theme/data.dart
@@ -24,6 +24,7 @@ class ShadcnThemeData extends ShadcnBaseTheme {
     ShadcnBadgeTheme? outlineBadgeTheme,
     BorderRadius? radius,
     ShadcnAvatarTheme? avatarTheme,
+    ShadcnButtonSizesTheme? buttonSizesTheme,
   }) {
     return ShadcnThemeData._internal(
       colorScheme: colorScheme,
@@ -60,6 +61,8 @@ class ShadcnThemeData extends ShadcnBaseTheme {
       outlineBadgeTheme: ShadcnComponentDefaultTheme.outlineBadgeTheme(
         colorScheme: colorScheme,
       ).mergeWith(outlineBadgeTheme),
+      buttonSizesTheme: ShadcnComponentDefaultTheme.buttonSizesTheme()
+          .mergeWith(buttonSizesTheme),
       radius: radius ?? const BorderRadius.all(Radius.circular(6)),
       avatarTheme: ShadcnComponentDefaultTheme.avatarTheme(
         colorScheme: colorScheme,
@@ -83,6 +86,7 @@ class ShadcnThemeData extends ShadcnBaseTheme {
     required super.outlineBadgeTheme,
     required super.radius,
     required super.avatarTheme,
+    required super.buttonSizesTheme,
   });
 
   static ShadcnThemeData lerp(ShadcnThemeData a, ShadcnThemeData b, double t) {
@@ -126,6 +130,11 @@ class ShadcnThemeData extends ShadcnBaseTheme {
           ShadcnBadgeTheme.lerp(a.outlineBadgeTheme, b.outlineBadgeTheme, t),
       radius: BorderRadius.lerp(a.radius, b.radius, t),
       avatarTheme: ShadcnAvatarTheme.lerp(a.avatarTheme, b.avatarTheme, t),
+      buttonSizesTheme: ShadcnButtonSizesTheme.lerp(
+        a.buttonSizesTheme,
+        b.buttonSizesTheme,
+        t,
+      ),
     );
   }
 
@@ -147,7 +156,8 @@ class ShadcnThemeData extends ShadcnBaseTheme {
         other.destructiveBadgeTheme == destructiveBadgeTheme &&
         other.outlineBadgeTheme == outlineBadgeTheme &&
         other.radius == radius &&
-        other.avatarTheme == avatarTheme;
+        other.avatarTheme == avatarTheme &&
+        other.buttonSizesTheme == buttonSizesTheme;
   }
 
   @override
@@ -165,7 +175,8 @@ class ShadcnThemeData extends ShadcnBaseTheme {
         outlineBadgeTheme.hashCode ^
         destructiveBadgeTheme.hashCode ^
         radius.hashCode ^
-        avatarTheme.hashCode;
+        avatarTheme.hashCode ^
+        buttonSizesTheme.hashCode;
   }
 
   ShadcnThemeData copyWith({
@@ -184,6 +195,7 @@ class ShadcnThemeData extends ShadcnBaseTheme {
     Iterable<ThemeExtension<dynamic>>? extensions,
     BorderRadius? radius,
     ShadcnAvatarTheme? avatarTheme,
+    ShadcnButtonSizesTheme? buttonSizesTheme,
   }) {
     return ShadcnThemeData(
       colorScheme: colorScheme ?? this.colorScheme,
@@ -203,6 +215,7 @@ class ShadcnThemeData extends ShadcnBaseTheme {
       outlineBadgeTheme: outlineBadgeTheme ?? this.outlineBadgeTheme,
       radius: radius ?? this.radius,
       avatarTheme: avatarTheme ?? this.avatarTheme,
+      buttonSizesTheme: buttonSizesTheme ?? this.buttonSizesTheme,
     );
   }
 }

--- a/lib/src/theme/themes/base.dart
+++ b/lib/src/theme/themes/base.dart
@@ -22,6 +22,7 @@ abstract class ShadcnBaseTheme {
     required this.outlineBadgeTheme,
     required this.radius,
     required this.avatarTheme,
+    required this.buttonSizesTheme,
   });
 
   final ShadcnColorScheme colorScheme;
@@ -39,4 +40,5 @@ abstract class ShadcnBaseTheme {
   final ShadcnBadgeTheme outlineBadgeTheme;
   final BorderRadius radius;
   final ShadcnAvatarTheme avatarTheme;
+  final ShadcnButtonSizesTheme buttonSizesTheme;
 }

--- a/lib/src/theme/themes/component_default.dart
+++ b/lib/src/theme/themes/component_default.dart
@@ -69,6 +69,28 @@ abstract class ShadcnComponentDefaultTheme {
     );
   }
 
+  static ShadcnButtonSizesTheme buttonSizesTheme() {
+    return const ShadcnButtonSizesTheme(
+      $default: ShadcnButtonSizeTheme(
+        height: 40,
+        padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      ),
+      sm: ShadcnButtonSizeTheme(
+        height: 36,
+        padding: EdgeInsets.symmetric(horizontal: 12),
+      ),
+      lg: ShadcnButtonSizeTheme(
+        height: 44,
+        padding: EdgeInsets.symmetric(horizontal: 32, vertical: 8),
+      ),
+      icon: ShadcnButtonSizeTheme(
+        height: 40,
+        width: 40,
+        padding: EdgeInsets.zero,
+      ),
+    );
+  }
+
   static ShadcnBadgeTheme primaryBadgeTheme({
     required ShadcnColorScheme colorScheme,
   }) {


### PR DESCRIPTION
This implements the button sizes presets into its own theme object for more customization. 
If presets are being provided then they just be customizable.
Having padding, height and width declared twice seems like bad practice

The order of importance for padding, height and width is as follows.
1. Use whatever is declared on the widget
2. If a size is declared **on** the widget, use the padding, height and width from the ButtonSizes theme.
3. Use size on global theme to get padding, height and width.